### PR TITLE
CLN: clean up interpolate to use blocks

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1164,7 +1164,6 @@ def backfill_2d(values, limit=None, mask=None):
         pass
     return values
 
-
 def _clean_interp_method(method):
     valid = ['linear', 'time', 'values', 'nearest', 'zero', 'slinear',
              'quadratic', 'cubic']

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -485,21 +485,31 @@ class TestDataFrame(unittest.TestCase, Generic):
         result = df.interpolate(index='C')
         expected = DataFrame({'A': [1, 2, 2.6666667, 4], 'B': [1, 4, 9, 9],
                               'C': [1, 2, 3, 5], 'D': list('abcd')})
+        assert_frame_equal(result, expected)
 
     def test_interp_combo(self):
         df = DataFrame({'A': [1., 2., np.nan, 4.], 'B': [1, 4, 9, np.nan],
-                'C': [1., 2., 3., 5.], 'D': list('abcd')})
+                        'C': [1., 2., 3., 5.], 'D': list('abcd')})
+
+        # these should return all the columns (but just interpolate on A)
+        result = df.interpolate(values='A')
+        expected = df.copy()
+        expected['A'] = Series([1,2,3,4])
+        assert_frame_equal(result, expected)
+
+        ## is the expected right here?
         result = df.interpolate(values='A', index='C')
-        expected = expected = DataFrame({'A': [1, 2, 3, 4], 'C': [1, 2, 3, 5]})
+        expected = df.copy()
+        expected['A'] = Series([1,2,3,4])
         assert_frame_equal(result, expected)
 
     def test_interp_leading_nan(self):
         df = DataFrame({'A': [1, 2, np.nan, 4], 'B': [np.nan, 2, 3, 4]})
         result = df.interpolate(values='A', index='B')
-        expected = DataFrame({'A': [1, 2, 3, 4]})
+        expected = DataFrame({'A': [1, 2, 3, 4], 'B' : df['B']})
         assert_frame_equal(result, expected)
 
-    def test_vairous(self):
+    def test_interp_various(self):
         df = DataFrame({'A': [1, 2, np.nan, 4, 5, np.nan, 7],
                         'C': [1, 2, 3, 5, 8, 13, 21]})
         result = df.interpolate(index='C', values='C', method=1)


### PR DESCRIPTION
Tom, here is your PR implemented with blocks. Should get you pretty far.

I am not sure of what exactly `df.interpolate(values='A',index='C')` is actually supposed to modify
e.g. use the values from column A to interpolate the remaining columns in the df with the index of C?

that is very odd though no way to pass it to your interp functions...?

lmk
