### PR TITLE
avoid use of .values

### DIFF
--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -187,7 +187,10 @@ def _use_inf_as_na(key):
 
 
 def _isna_ndarraylike(obj):
-    values = getattr(obj, 'values', obj)
+    if not is_extension_array_dtype(obj):
+        values = getattr(obj, 'values', obj)
+    else:
+        values = obj
     dtype = values.dtype
 
     if is_extension_array_dtype(obj):

--- a/pandas/tests/arrays/test_period.py
+++ b/pandas/tests/arrays/test_period.py
@@ -51,7 +51,7 @@ def test_setitem_raises():
     (pd.date_range("2017", periods=3), None, [17167, 17168, 17169]),
 ])
 def test_period_array_ok(data, freq, expected):
-    result = period_array(data, freq=freq).values
+    result = period_array(data, freq=freq)._data
     expected = np.asarray(expected, dtype=np.int64)
     tm.assert_numpy_array_equal(result, expected)
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1055,7 +1055,7 @@ def assert_interval_array_equal(left, right, exact='equiv',
 def assert_period_array_equal(left, right, obj='PeriodArray'):
     _check_isinstance(left, right, PeriodArray)
 
-    assert_numpy_array_equal(left.values, right.values,
+    assert_numpy_array_equal(left._data, right._data,
                              obj='{obj}.values'.format(obj=obj))
     assert_attr_equal('freq', left, right, obj=obj)
 


### PR DESCRIPTION
Testing a bit where `.values` is still used