### PR TITLE
Diff reduction for 24024

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1162,10 +1162,9 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
         left = lib.values_from_object(self.astype('O'))
 
         res_values = op(left, np.array(other))
-        kwargs = {}
         if not is_period_dtype(self):
-            kwargs['freq'] = 'infer'
-        return self._from_sequence(res_values, **kwargs)
+            return type(self)(res_values, freq='infer')
+        return self._from_sequence(res_values)
 
     def _time_shift(self, periods, freq=None):
         """

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -255,7 +255,7 @@ class TimedeltaArrayMixin(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
 
         return cls._simple_new(index, freq=freq)
 
-    # -----------------------------------------------------------------
+    # ----------------------------------------------------------------
     # DatetimeLike Interface
 
     def _unbox_scalar(self, value):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -44,7 +44,7 @@ def ea_passthrough(name):
     method
     """
     def method(self, *args, **kwargs):
-        return getattr(self._data, name)(*args, **kwargs)
+        return getattr(self._eadata, name)(*args, **kwargs)
 
     method.__name__ = name
     # TODO: docstrings
@@ -80,11 +80,12 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
         """
         Return the frequency object if it is set, otherwise None.
         """
-        return self._data.freq
+        return self._eadata.freq
 
     @freq.setter
     def freq(self, value):
-        self._data.freq = value
+        # validation is handled by _eadata setter
+        self._eadata.freq = value
 
     @property
     def freqstr(self):
@@ -132,12 +133,12 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
     def values(self):
         # type: () -> np.ndarray
         # Note: PeriodArray overrides this to return an ndarray of objects.
-        return self._data._data
+        return self._eadata._data
 
     @property
     @Appender(DatetimeLikeArrayMixin.asi8.__doc__)
     def asi8(self):
-        return self._data.asi8
+        return self._eadata.asi8
 
     # ------------------------------------------------------------------------
 
@@ -743,16 +744,16 @@ class DatetimelikeDelegateMixin(PandasDelegate):
         raise AbstractMethodError
 
     def _delegate_property_get(self, name, *args, **kwargs):
-        result = getattr(self._data, name)
+        result = getattr(self._eadata, name)
         if name not in self._raw_properties:
             result = Index(result, name=self.name)
         return result
 
     def _delegate_property_set(self, name, value, *args, **kwargs):
-        setattr(self._data, name, value)
+        setattr(self._eadata, name, value)
 
     def _delegate_method(self, name, *args, **kwargs):
-        result = operator.methodcaller(name, *args, **kwargs)(self._data)
+        result = operator.methodcaller(name, *args, **kwargs)(self._eadata)
         if name not in self._raw_methods:
             result = Index(result, name=self.name)
         return result

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1476,7 +1476,7 @@ class TestTimedeltaArraylikeMulDivOps(object):
 
         tdi = TimedeltaIndex(['1 Day'] * 10)
         expected = timedelta_range('1 days', '10 days')
-        expected._data.freq = None
+        expected._eadata.freq = None
 
         tdi = tm.box_expected(tdi, box)
         expected = tm.box_expected(expected, xbox)

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -318,7 +318,8 @@ class TestToPeriod(object):
                                         pd.Timestamp('2000-01-02', tz=tz)])
         tm.assert_index_equal(result, expected)
 
-        result = obj._data.astype('category')
+        # TODO: use \._data following composition changeover
+        result = obj._eadata.astype('category')
         expected = expected.values
         tm.assert_categorical_equal(result, expected)
 

--- a/pandas/tests/indexes/timedeltas/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/test_astype.py
@@ -95,7 +95,8 @@ class TestTimedeltaIndex(object):
                                         pd.Timedelta('2H')])
         tm.assert_index_equal(result, expected)
 
-        result = obj._data.astype('category')
+        # TODO: Use \._data following composition changeover
+        result = obj._eadata.astype('category')
         expected = expected.values
         tm.assert_categorical_equal(result, expected)
 


### PR DESCRIPTION
cc @TomAugspurger 

reverted foo._eadata -> foo._data changes as discussed; they'll be super-easy to get rid of in a follow-up.

The only "real" change is in arrays.datetimelike, where I tried to get the 24024 version in 24543 and jreback said to revert, so reverted it here too.